### PR TITLE
V1.0.1

### DIFF
--- a/BenchmarkTest/Program.cs
+++ b/BenchmarkTest/Program.cs
@@ -32,7 +32,7 @@ namespace BenchmarkTest
         public void ReflectionToString() => Data.Select(instance => {
             var type = instance.GetType();
             var props = type.GetProperties();
-            return props.ToDictionary(key => key.Name, value => value.GetValue(instance).ToString());
+            return props.ToDictionary(key => key.Name, value => value.GetValue(instance)?.ToString());
         }).ToList();
 
         [Benchmark()]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,2 @@
+﻿### version 1.0.1
+- [X] Fix [If Property Value Is Null GetToStringValue will get System.NullReferenceException · Issue #1 ](https://github.com/shps951023/ValueGetter/issues/1)

--- a/ValueGetter.sln
+++ b/ValueGetter.sln
@@ -17,6 +17,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
+		Changelog.md = Changelog.md
 		LICENSE = LICENSE
 		Readme.md = Readme.md
 		Readme_zh-cn.md = Readme_zh-cn.md

--- a/ValueGetter/ValueGetter.csproj
+++ b/ValueGetter/ValueGetter.csproj
@@ -6,23 +6,24 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 
     <Authors>ITWeiHan</Authors>
-    <Description>
-      Mini and User Friendly C# Utilities.
-      More Details in Github Link : [ValueGetter: Mini and User Friendly C# Utilities.](https://github.com/shps951023/ValueGetter)
-    </Description>
+    <Description>Mini/Faster Object Property Value Getter.
+More Details in Github Link : [ValueGetter: Mini/Faster Object Property Value Getter. ](https://github.com/shps951023/ValueGetter)
+</Description>
     <Copyright>©2019 WeiHan Lin</Copyright>
     <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/shps951023/ValueGetter</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/shps951023/ImageHosting/master/img/2019-01-17.13.18.32-image.png</PackageIconUrl>
 
-    <AssemblyVersion>1.0.0</AssemblyVersion>
-    <FileVersion>1.0.0</FileVersion>
-    <Version>1.0.0</Version>
+    <AssemblyVersion>1.0.1</AssemblyVersion>
+    <FileVersion>1.0.1</FileVersion>
+    <Version>1.0.1</Version>
     <PackageId>ValueGetter</PackageId>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>ValueGetter</Product>
-    <PackageTags>ValueGetter,Unity,Easy</PackageTags>
+    <PackageTags>ValueGetter,GetValue,Mini,Easy</PackageTags>
     <RepositoryType>Github</RepositoryType>
+    <PackageReleaseNotes>### version 1.0.1
+- [X] Fix [If Property Value Is Null GetToStringValue will get System.NullReferenceException · Issue #1 ](https://github.com/shps951023/ValueGetter/issues/1)</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'netstandard2.0'">

--- a/ValueGetterTests/ToStringValueHelperTests.cs
+++ b/ValueGetterTests/ToStringValueHelperTests.cs
@@ -112,7 +112,7 @@ namespace ValueGetterTests
         }
 
         [TestMethod]
-        public void PropNull()
+        public void IstanceIsNull()
         {
             MyClass data = null;
             var props = typeof(MyClass).GetProperties();
@@ -121,6 +121,14 @@ namespace ValueGetterTests
                 //var result = prop.GetValue(data); //System.Reflection.TargetException: 'Non-static method requires a target.'
                 var result =  prop.GetObjectValue(data);
             }
+        }
+
+        [TestMethod]
+        public void PropertyValueIsNull()
+        {
+            MyClass data = new MyClass { MyProperty2=null} ;
+            var result = data.GetToStringValues()["MyProperty2"] ; //System.NullReferenceException: 'Object reference not set to an instance of an object.'
+            Assert.IsNull(result);
         }
     }
 }


### PR DESCRIPTION
### version 1.0.1
- [X] Fix [If Property Value Is Null GetToStringValue will get System.NullReferenceException · Issue #1 ](https://github.com/shps951023/ValueGetter/issues/1)